### PR TITLE
Switch dependency from youtube_dl to yt_dlp

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 moviepy<1.1,>=1.0
 pydantic<1.11,>=1.10
-youtube_dl==2021.12.17
+yt-dlp==2023.2.17
 click<8.2,>=8.1
 pandas<1.6,>=1.5

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -1,5 +1,5 @@
-from unittest import mock
 import pytest
+from unittest import mock
 from ytb_downloader.downloader import (
     download, YDL_VIDEO_OPTS, YDL_AUDIO_OPTS
 )
@@ -10,13 +10,14 @@ from ytb_downloader.downloader import (
                          (YDL_AUDIO_OPTS, YDL_AUDIO_OPTS),
                          (YDL_VIDEO_OPTS, YDL_VIDEO_OPTS)])
 @mock.patch("ytb_downloader.downloader.logger")
-@mock.patch("ytb_downloader.downloader.youtube_dl")
-def test_download_fail(mocked_youtube_dl, mocked_logger, ydl_opts, expected_ydl_opts):
-    mocked_youtube_dl.YoutubeDL.side_effect = ValueError("dummy")
-    result = download(["dummy"], ydl_opts)
-    assert result == []
+@mock.patch("ytb_downloader.downloader.yt_dlp")
+def test_download_fail(mocked_yt_dlp, mocked_logger, ydl_opts, expected_ydl_opts):
+    mocked_yt_dlp.YoutubeDL.side_effect = ValueError("dummy")
+    with pytest.raises(ValueError) as e:
+        download(["dummy"], ydl_opts)
+    assert str(e.value) == "dummy"
     mocked_logger.error.assert_called_once_with('The error [dummy] occurred during downloading the videos.')
-    mocked_youtube_dl.YoutubeDL.assert_called_once_with(expected_ydl_opts)
+    mocked_yt_dlp.YoutubeDL.assert_called_once_with(expected_ydl_opts)
 
 
 @pytest.mark.parametrize("ydl_opts, expected_ydl_opts",
@@ -25,11 +26,11 @@ def test_download_fail(mocked_youtube_dl, mocked_logger, ydl_opts, expected_ydl_
                           (None, YDL_AUDIO_OPTS)])
 @mock.patch("ytb_downloader.downloader.FileNameCollectorPP")
 @mock.patch("ytb_downloader.downloader.logger")
-@mock.patch("ytb_downloader.downloader.youtube_dl")
-def test_download_success(mocked_youtube_dl, mocked_logger, mocked_fnc, ydl_opts, expected_ydl_opts):
+@mock.patch("ytb_downloader.downloader.yt_dlp")
+def test_download_success(mocked_yt_dlp, mocked_logger, mocked_fnc, ydl_opts, expected_ydl_opts):
     mocked_fnc.return_value = mock.MagicMock(file_names=["1", "2"])
     result = download(["dummy"], ydl_opts)
     assert result == ["1", "2"]
     mocked_logger.assert_not_called()
-    mocked_youtube_dl.YoutubeDL.assert_called_once_with(expected_ydl_opts)
+    mocked_yt_dlp.YoutubeDL.assert_called_once_with(expected_ydl_opts)
 

--- a/ytb_downloader/downloader.py
+++ b/ytb_downloader/downloader.py
@@ -1,6 +1,6 @@
 """This module contains functions for downloading videos from youtube."""
 import logging
-import youtube_dl  # type: ignore
+import yt_dlp  # type: ignore
 from typing import List, Dict, Optional
 from .config import settings
 from .file_name_collector import FileNameCollectorPP
@@ -23,22 +23,21 @@ def download(urls: List[str], ydl_opts: Optional[Dict] = None) -> List[str]:
     Args:
         urls (:obj:`list` of :obj:`str`): urls to the videos in
           youtube, you can get it through copying the url in address bar.
-        ydl_opts (:obj:`dict`): youtube_dl's options.
+        ydl_opts (:obj:`dict`): yt_dlp's options.
 
     Returns:
         :obj:`list` of :obj:`str`: Downloaded youtube video file names.
     """
     ydl_opts = ydl_opts or YDL_AUDIO_OPTS
-    output_files = []
     try:
-        with youtube_dl.YoutubeDL(ydl_opts) as ydl:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             filename_collector = FileNameCollectorPP()
             ydl.cache.remove()
             ydl.add_post_processor(filename_collector)
             ydl.download(urls)
-            output_files = filename_collector.file_names
+            return filename_collector.file_names
     except Exception as e:
         error_msg = "The error [{}] occurred during downloading " \
                     "the videos.".format(str(e))
         logger.error(error_msg)
-    return output_files
+        raise e

--- a/ytb_downloader/file_name_collector.py
+++ b/ytb_downloader/file_name_collector.py
@@ -1,10 +1,10 @@
 """Extracting downloaded files' names."""
-import youtube_dl  # type: ignore
+import yt_dlp  # type: ignore
 from typing import Tuple, Dict, List
 
 
-class FileNameCollectorPP(youtube_dl.postprocessor.common.PostProcessor):
-    """Collect file names from the youtube_dl for downloaded videos as an post
+class FileNameCollectorPP(yt_dlp.postprocessor.common.PostProcessor):
+    """Collect file names from the yt_dlp for downloaded videos as an post
     processing step.
 
     Attributes:


### PR DESCRIPTION
1. Change dependency from youtube_dl to yt_dlp, since it has been inactive more than 1 year; 
2. Raise error when yt_dlp cannot download video.